### PR TITLE
[Fix issue#14] -- Set gRPC Channel based on DSN scheme

### DIFF
--- a/beacon/agent.py
+++ b/beacon/agent.py
@@ -86,7 +86,7 @@ class Agent(object):
         self.tracer = Tracer(buffer=self.buffers['function'], **options)
 
         # create a stub for this agent
-        channel = grpc.insecure_channel(self.dsn.host)
+        channel = self._get_grpc_channel()
         self.stub = pb2_grpc.BeaconStub(channel)
 
         # set the logger
@@ -147,3 +147,13 @@ class Agent(object):
 
     def _set_source_version(self, source_version):
         self.source_version = source_version
+
+    def _get_grpc_channel(self):
+        """Returns a secure/insecure gRPC Channel instance"""
+        if self.dsn.has_secure_scheme():
+            ssl_credentials = grpc.ssl_channel_credentials()
+            channel = grpc.secure_channel(self.dsn.host, ssl_credentials)
+        else:
+            channel = grpc.insecure_channel(self.dsn.host)
+
+        return channel

--- a/beacon/utils.py
+++ b/beacon/utils.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """Utilities for Beacon."""
+from __future__ import unicode_literals
+
 import re
 import threading
 import time
@@ -153,3 +155,6 @@ class DSN(object):
             "<scheme>://<api-key>@<beacon-server-hostname>/<repository-id>"
             .format(self.input_dsn_string)
         )
+
+    def has_secure_scheme(self):
+        return self.scheme.lower() == 'https'


### PR DESCRIPTION
Fixes deepsourcelabs/beacon-py#14

During Agent initialization, the gRPC Channel is created based on the DSN scheme. For secure scheme, `grpc.secure_channel` and `grpc.insecure_channel` otherwise.

Signed-off-by: Abeer Upadhyay <ab.esquarer@gmail.com>